### PR TITLE
fix(api): await BEGIN in closePredictionById to avoid pg concurrent query warning

### DIFF
--- a/api/src/db/queries/predictions/index.ts
+++ b/api/src/db/queries/predictions/index.ts
@@ -60,7 +60,7 @@ const closePredictionById = (client: PoolClient) =>
     triggerer_id: number | string | null,
     closed_date: Date
   ): Promise<APIPredictions.ClosePredictionById> {
-    client.query("BEGIN");
+    await client.query("BEGIN");
 
     try {
       // Ensure any open checks are closed


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`closePredictionById` started a transaction with `client.query("BEGIN")` but did not `await` it. The next `await client.query(...)` could run while BEGIN was still in flight on the same `PoolClient`, which triggers pg’s deprecation: *Calling client.query() when the client is already executing a query*.

## Change

- Await `BEGIN` before any further queries in `closePredictionById`.

## Validation

- `pnpm exec tsc --noEmit` in `api/` passes.
- Integration tests that hit this path were not re-run here (no test DB in this environment); please run `pnpm --filter ndb2-api test` with the test stack up to confirm the warning is gone.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7bf1d34f-929e-4a1f-bccf-d70ec603942f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7bf1d34f-929e-4a1f-bccf-d70ec603942f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

