### PR TITLE
Run test workflow on non-draft PR commits

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,12 @@ name: Test Suite
 
 on:
   workflow_dispatch:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
 
 jobs:
   test:
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The Test Suite workflow was only triggered manually via `workflow_dispatch`. This change runs it automatically on pull request activity so every new commit on a non-draft PR runs the full test job.

## Changes

- **`pull_request`**: Triggers on `opened`, `synchronize` (new commits), `reopened`, and `ready_for_review` (when a draft is marked ready).
- **Skip drafts**: The `test` job uses `if:` so it does not run while the PR is in draft state; marking the PR ready triggers `ready_for_review` and runs the suite.

`workflow_dispatch` is unchanged so you can still run the workflow manually when needed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b3389483-41c0-4a29-9cde-a9a5397401ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b3389483-41c0-4a29-9cde-a9a5397401ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

