### PR TITLE
fix(db): avoid running Vitest on both src and dist

### DIFF
--- a/db/vitest.config.ts
+++ b/db/vitest.config.ts
@@ -5,5 +5,8 @@ export default defineConfig({
     globalSetup: "./src/test/global-setup.ts",
     globals: true,
     environment: "node",
+    // Default Vitest globs match both src and emitted dist/*.test.js; run source tests only.
+    include: ["src/**/*.{test,spec}.?(c|m)[jt]s?(x)"],
+    exclude: ["**/node_modules/**", "**/dist/**"],
   },
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The `@offnominal/ndb2-db` package builds TypeScript into `dist/`, which includes emitted `*.test.js` files. Vitest’s default test globs matched both `src/**/*.test.ts` and `dist/**/*.test.js`, so the same tests ran twice (62 tests instead of 31).

## Change

In `db/vitest.config.ts`, set explicit `include` (only under `src/`) and `exclude` (`dist/`) so tests execute against source only.

Verified locally with `pnpm --filter @offnominal/ndb2-db test:run`: one test file, 31 tests.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b3389483-41c0-4a29-9cde-a9a5397401ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b3389483-41c0-4a29-9cde-a9a5397401ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

