### PR TITLE
Fix PATCH snooze tests: use event-driven prediction seeds

### DIFF
--- a/api/src/v2/routes/predictions/patch_predictions_{predictionId}_snooze.test.ts
+++ b/api/src/v2/routes/predictions/patch_predictions_{predictionId}_snooze.test.ts
@@ -67,7 +67,7 @@ describe("PATCH /predictions/:prediction_id/snooze", () => {
 
   it("should reject retired predictions", async () => {
     const response = await request(app)
-      .patch("/6/snooze")
+      .patch("/11/snooze")
       .send({
         discord_id: "111111111111111111",
         check_date: futureIso(),
@@ -85,7 +85,7 @@ describe("PATCH /predictions/:prediction_id/snooze", () => {
     const emitSpy = vi.spyOn(eventsManager, "emit");
 
     const response = await request(app)
-      .patch("/4/snooze")
+      .patch("/10/snooze")
       .send({
         discord_id: "111111111111111111",
         check_date: futureIso(),
@@ -93,7 +93,7 @@ describe("PATCH /predictions/:prediction_id/snooze", () => {
 
     expect(response.status).toBe(200);
     expect(response.body.data).toBeDefined();
-    expect(response.body.data.id).toBe(4);
+    expect(response.body.data.id).toBe(10);
     expect(emitSpy).toHaveBeenCalledWith(
       "prediction_edit",
       expect.any(Object),

--- a/db/src/seeds/test/predictions.json
+++ b/db/src/seeds/test/predictions.json
@@ -358,5 +358,33 @@
         "vote": true
       }
     ]
+  },
+  {
+    "id": 10,
+    "user_id": "550e8400-e29b-41d4-a716-446655440001",
+    "text": "Test event-driven prediction with open status (PATCH snooze tests)",
+    "driver": "event",
+    "baseDate": {
+      "days": 0
+    },
+    "check_date": {
+      "days": 25
+    }
+  },
+  {
+    "id": 11,
+    "user_id": "550e8400-e29b-41d4-a716-446655440001",
+    "text": "Test event-driven prediction with retired status (PATCH snooze tests)",
+    "driver": "event",
+    "baseDate": {
+      "quarter": "past",
+      "days": 10
+    },
+    "check_date": {
+      "days": 20
+    },
+    "retired": {
+      "days": 5
+    }
   }
 ]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

`PATCH /predictions/:prediction_id/snooze` only allows **event**-driven predictions (`INVALID_PREDICTION_DRIVER` otherwise). The snooze tests used seeded IDs **4** and **6**, which are **date**-driven in `db/src/seeds/test/predictions.json`. The handler therefore returned **400** with the wrong error code, so:

- “reject retired predictions” did not see `INVALID_PREDICTION_STATUS`.
- “open prediction” did not reach **200**.

## Change

- Added test seeds **10** (event, open) and **11** (event, retired) in `db/src/seeds/test/predictions.json`.
- Pointed `patch_predictions_{predictionId}_snooze.test.ts` at `/10/snooze` and `/11/snooze` and asserted `id` **10** for the success case.

CI must re-seed the test DB (global setup runs `reset`) so the new rows exist.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b3389483-41c0-4a29-9cde-a9a5397401ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b3389483-41c0-4a29-9cde-a9a5397401ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

